### PR TITLE
add skipping to start `ssh-agent`

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,5 +5,5 @@
 export PRIVATEKEY_PATH=`mktemp`
 privateKey=$(eval echo "\$${WERCKER_ADD_DEPLOY_SSH_KEY_KEYNAME}_PRIVATE")
 echo -e "$privateKey" > $PRIVATEKEY_PATH
-eval `ssh-agent -s`
+if [[ ! -n $SSH_AGENT_PID ]]; then eval `ssh-agent -s`; fi
 ssh-add $PRIVATEKEY_PATH


### PR DESCRIPTION
Hi, Thanks for you nice product.

I want to add 2nd key to ssh-agent.

```yaml
deploy:
  steps:
    - williamli/add-deploy-ssh-key:
        keyname: GITHUB_KEY
    - williamli/add-deploy-ssh-key:
        keyname: DEPLOY_KEY
```

But, 2nd key is disabled because ssh-agent run every steps.

Please check my fix.
Thank you.